### PR TITLE
Add support for reading from Zip archives containing firmware.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,17 @@ Download the firmware to use:
 
     $ curl -o digicap.dav <url of firmware>
 
+    or
+
+    $ curl -o firmware.zip <url of firmware>
+
 Run the script:
 
-    $ sudo ./hikvision_tftpd.py
+    $ sudo ./hikvision_tftpd.py digicap.dav
+
+    or
+
+    $ sudo ./hikvision_tftpd.py firmware.zip
 
 Hit ctrl-C when done.
 
@@ -35,7 +43,7 @@ there are two known configurations:
 
 This program defaults to the former. The latter requires commandline overrides:
 
-    $ sudo ./hikvision_tftp.py --server-ip=172.9.18.80 --filename=digicap.mav
+    $ sudo ./hikvision_tftp.py --server-ip=172.9.18.80 digicap.mav 
 
 If nothing happens when your device restarts, your device may be expecting
 another IP address. tcpdump may be helpful in diagnosing this:


### PR DESCRIPTION
Most camera firmware comes as a Zip archive containing the `digicap.dav` file. This change adds support for reading firmware files directly from Zip archives, to avoid the interim step of extracting the archive to disk. The Zip archive usually has a descriptive name (camera generation, language, version, etc, ex: `IPC_G0_EN_STD_5.5.88_200610.zip`). If one is experimenting with a selection of firmware files, keeping them zipped is cleaner and easier to deal with.

Essentially, users can now simply do:

```
sudo ./hikvision_tftpd.py IPC_G0_EN_STD_5.5.88_200610.zip
```

and everything will *just work*™